### PR TITLE
Update service.ts

### DIFF
--- a/src/executors/service.ts
+++ b/src/executors/service.ts
@@ -1,8 +1,8 @@
 import { Constructor, Token } from "@kaviar/core";
 
 export function ToService<T>(
-  serviceClass: Constructor<T> | any,
-  methodName: string,
+  serviceClass: Constructor<T>,
+  methodName: keyof T,
   argumentMapper?: (args, ctx, ast) => any[]
 ) {
   if (!argumentMapper) {


### PR DESCRIPTION
Can `serviceClass` be something other than `Constructor<T>`? if not, we can remove `any` from the union and give methodName the type `keyof T`. This way, we can have autocompletion.